### PR TITLE
Comfort tweaks and 3.5 inch Waveshare timings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+ENV TZ=Europe/Stockholm
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y vim git make gcc bison flex libssl-dev bc ncurses-dev kmod xa65 texinfo curl tar xz-utils automake-1.15
+
+RUN curl -Lo gcc-arm-none-eabi.tar.bz2 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&rev=05382cca172144e1ae191e7c3dc96118&hash=FDE675133A099796BD1507A3FF215AC4"
+RUN mkdir /opt/gcc-arm-none-eabi
+RUN tar xvjf gcc-arm-none-eabi.tar.bz2 --strip-components=1 -C /opt/gcc-arm-none-eabi
+ENV ARM_HOME=/opt/gcc-arm-none-eabi
+ENV PATH=$PATH:$ARM_HOME/bin
+ENV ARM_VERSION=9.3.1
+RUN mkdir /build
+RUN git -C /build clone --recursive https://github.com/henrikenblom/bmc64.git

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 BMC64 is a bare metal C64 emulator for the Raspberry Pi with true 50hz/60hz smooth scrolling and low latency between input & video/audio. Four other Commodore machines are available as well; C128, Vic20, Plus/4 and PET.
 
+# How this fork differs from the original
+At the time of writing, these are the differences:
+  * Volume down/up using F10/F11
+  * FPS out of range message in the timing menu outputs the measured FPS. (Helpful when creating custom timings.)
+  * make_machines.sh makes C64 the default kernel image
+  * C64 machine settings for the Waveshare 3.5" 640x480 DPI LCD
+  * Dockerfile that sets up a build environment with all the needed dependencies and some useful tools
+
 # BMC64 Features
   * Quick boot time (C64 in 4.1 seconds over composite!)
   * Frames are timed to vsync for true 50/60 hz smooth scrolling (no horizontal tearing!)

--- a/make_all.sh
+++ b/make_all.sh
@@ -51,17 +51,17 @@ echo APPLY PATCHES
 echo ==============================================================
 
 cd $SRC_DIR/third_party/circle-stdlib/libs/circle-newlib
-patch -p1 < ../../../../circle_newlib_patch.diff
+patch -N -p1 < ../../../../circle_newlib_patch.diff
 
 cd $SRC_DIR/third_party/circle-stdlib/libs/circle
 
 if [ "$BOARD" = "pi0" ]
 then
-cat ../../../../circle_patch.diff | sed 's@+#define ARM_ALLOW_MULTI_CORE@+//#define ARM_ALLOW_MULTI_CORE@' | patch -p1
+cat ../../../../circle_patch.diff | sed 's@+#define ARM_ALLOW_MULTI_CORE@+//#define ARM_ALLOW_MULTI_CORE@' | patch -N -p1
 perl -pi -e 's@#define USE_PHYSICAL_COUNTER@//#define USE_PHYSICAL_COUNTER@' ./include/circle/sysconfig.h
 perl -pi -e 's@//#define SAVE_VFP_REGS_ON_IRQ@#define SAVE_VFP_REGS_ON_IRQ@' ./include/circle/sysconfig.h
 else
-patch -p1 < ../../../../circle_patch.diff
+patch -N -p1 < ../../../../circle_patch.diff
 fi
 
 echo ==============================================================
@@ -73,19 +73,19 @@ cd $SRC_DIR/third_party/circle-stdlib
 
 if [ "$BOARD" = "pi2" ]
 then
-cat ../../circle_stdlib_patch.diff  | sed 's/-std=c++14//' | patch -p1
+cat ../../circle_stdlib_patch.diff  | sed 's/-std=c++14//' | patch -N -p1
 ./configure --raspberrypi=2
 elif [ "$BOARD" = "pi0" ]
 then
-cat ../../circle_stdlib_patch.diff | patch -p1
+cat ../../circle_stdlib_patch.diff | patch -N -p1
 ./configure --raspberrypi=1
 elif [ "$BOARD" = "pi3" ]
 then
-cat ../../circle_stdlib_patch.diff  | patch -p1
+cat ../../circle_stdlib_patch.diff  | patch -N -p1
 ./configure --raspberrypi=3
 elif [ "$BOARD" = "pi4" ]
 then
-cat ../../circle_stdlib_patch.diff  | patch -p1
+cat ../../circle_stdlib_patch.diff  | patch -N -p1
 ./configure --raspberrypi=4
 else
 echo "I don't know what to do for $BOARD"

--- a/make_machines.sh
+++ b/make_machines.sh
@@ -39,7 +39,7 @@ cd third_party/plus4emu
 make
 cd ../..
 
-MACHINES="C64:c64 C128:c128 VIC20:vic20 Plus4:plus4 Plus4Emu:plus4emu PET:pet"
+MACHINES="C128:c128 VIC20:vic20 Plus4:plus4 Plus4Emu:plus4emu PET:pet C64:c64"
 
 for m in $MACHINES
 do

--- a/sdcard/machines.txt
+++ b/sdcard/machines.txt
@@ -168,6 +168,48 @@ machine_timing=pal-custom
 cycles_per_second=985257
 scaling_params=384,272,768,544
 
+# NTSC Settings for the Waveshare 3.5" 640x480 DPI LCD
+# https://www.waveshare.com/wiki/3.5inch_DPI_LCD
+[C64/NTSC/DPI/VICE 480p@59.851Hz]
+enable_dpi=true
+machine_timing=ntsc-custom
+cycles_per_second=1023164
+enable_dpi_lcd=1
+display_default_lcd=1
+gpio=0-9=a2
+gpio=12-17=a2
+gpio=20-25=a2
+dtoverlay=dpi18
+enable_dpi_lcd=1
+display_default_lcd=1
+extra_transpose_buffer=2
+dpi_group=2
+dpi_mode=87
+dpi_output_format=0x6f006
+dpi_timings=640 0 20 10 10 480 0 273 10 5 0 0 0 60 0 31253820 1
+scaling_params=364,240,640,480
+
+# PAL Settings for the Waveshare 3.5" 640x480 DPI LCD
+# https://www.waveshare.com/wiki/3.5inch_DPI_LCD
+[C64/PAL/DPI/VICE 480p@50.126Hz]
+enable_dpi=true
+machine_timing=pal-custom
+cycles_per_second=985289
+enable_dpi_lcd=1
+display_default_lcd=1
+gpio=0-9=a2
+gpio=12-17=a2
+gpio=20-25=a2
+dtoverlay=dpi18
+enable_dpi_lcd=1
+display_default_lcd=1
+extra_transpose_buffer=2
+dpi_group=2
+dpi_mode=87
+dpi_output_format=0x6f006
+dpi_timings=640 0 20 10 10 480 0 422 10 5 0 0 0 50 0 31253820 1
+scaling_params=364,240,640,480
+
 #
 # C128
 #

--- a/third_party/common/circle.h
+++ b/third_party/common/circle.h
@@ -112,6 +112,10 @@
 #define BTN_ASSIGN_RESET_MENU 29
 #define BTN_ASSIGN_FLUSH_DISK 30
 
+// For devices without external volume control
+#define BTN_ASSIGN_VOLUME_UP 100
+#define BTN_ASSIGN_VOLUME_DOWN 101
+
 // These are intermediate values not meant to
 // be directly assigned to buttons. Never used as
 // an index into anything.

--- a/third_party/common/kbd.c
+++ b/third_party/common/kbd.c
@@ -453,6 +453,14 @@ void emu_key_released(long key) {
     return;
   }
 
+  if (key == KEYCODE_F10) {
+    emu_quick_func_interrupt(BTN_ASSIGN_VOLUME_DOWN);
+  }
+
+  if (key == KEYCODE_F11) {
+    emu_quick_func_interrupt(BTN_ASSIGN_VOLUME_UP);
+  }
+
   // Intercept keys meant to become joystick values
   if (joydevs[0].device == JOYDEV_NUMS_1 ||
       joydevs[0].device == JOYDEV_NUMS_2 ||

--- a/third_party/common/menu.c
+++ b/third_party/common/menu.c
@@ -3998,6 +3998,21 @@ void menu_quick_func(int button_assignment) {
     c40_80_column_item->value = 1 - c40_80_column_item->value;
     menu_value_changed(c40_80_column_item);
     break;
+  case BTN_ASSIGN_VOLUME_DOWN:
+    volume_item->value -= 10;
+    if (volume_item->value < 0) {
+      // TODO: '0' isn't completely quiet. Find out if muting is possible for this case.
+      volume_item->value = 0;
+    }
+    menu_value_changed(volume_item);
+    break;
+  case BTN_ASSIGN_VOLUME_UP:
+    volume_item->value += 10;
+    if (volume_item->value > 100) {
+      volume_item->value = 100;
+    }
+    menu_value_changed(volume_item);
+    break;
   default:
     break;
   }

--- a/third_party/common/menu_timing.c
+++ b/third_party/common/menu_timing.c
@@ -109,7 +109,7 @@ static void calc_popped(struct menu_item *new_root,
     tmp_item = ui_menu_add_button(MENU_TEXT, root, "");
     sprintf(tmp_item->name, "Actual fps = %f", fps);
   } else {
-    ui_error("FPS OUT OF RANGE!");
+    ui_error("OUT OF RANGE: %f", fps);
   }
 
   hdmi_timing_count = 0;


### PR DESCRIPTION
- Volume down/up using F10/F11
- FPS out of range message in the timing menu outputs the measured FPS. (Helpful when creating custom timings.)
- make_machines.sh makes C64 the default kernel image C64 machine settings for the Waveshare 3.5" 640x480 DPI LCD
- Dockerfile that sets up a build environment with all the needed dependencies and some useful tools