### PR TITLE
Fix for mouse jumping while clicking #248

### DIFF
--- a/third_party/common/menu_usb.c
+++ b/third_party/common/menu_usb.c
@@ -347,6 +347,11 @@ void build_usb_menu(int dev, struct menu_item *root) {
   y_axis_item->on_value_changed = menu_usb_value_changed;
   x_thresh_item->on_value_changed = menu_usb_value_changed;
   y_thresh_item->on_value_changed = menu_usb_value_changed;
+
+  potx_high_item->on_value_changed = menu_usb_value_changed;
+  potx_low_item->on_value_changed = menu_usb_value_changed;
+  poty_high_item->on_value_changed = menu_usb_value_changed;
+  poty_low_item->on_value_changed = menu_usb_value_changed;
 }
 
 int emu_wants_raw_usb(void) {

--- a/third_party/vice-3.3/configure.proto
+++ b/third_party/vice-3.3/configure.proto
@@ -1218,9 +1218,9 @@ dnl fi
 
 AC_PROG_LEX
 
-if test x"$LEX" = "x:"; then
-  AC_MSG_ERROR([Could not find either flex or lex!])
-fi
+dnl if test x"$LEX" = "x:"; then
+dnl  AC_MSG_ERROR([Could not find either flex or lex!])
+dnl fi
 
 AM_PROG_AS
 

--- a/third_party/vice-3.3/src/c128/z80.c
+++ b/third_party/vice-3.3/src/c128/z80.c
@@ -444,8 +444,6 @@ static const uint8_t SZP[256] = {
 
 /* ------------------------------------------------------------------------- */
 
-z80_regs_t z80_regs;
-
 static void import_registers(void)
 {
     reg_a = z80_regs.reg_af >> 8;

--- a/third_party/vice-3.3/src/joyport/joystick.c
+++ b/third_party/vice-3.3/src/joyport/joystick.c
@@ -56,6 +56,12 @@
 #include "userport_joystick.h"
 #include "vice-event.h"
 
+#ifdef HAVE_MOUSE
+#ifdef RASPI_COMPILE
+#include "mouse.h"
+#endif
+#endif
+
 /* Control port <--> Joystick connections:
 
    cport | joystick | I/O
@@ -812,11 +818,11 @@ void joystick_set_poty_or(int port, uint8_t value)
 
 static uint8_t joystick_read_potx(int port)
 {
-    return joystick_potx_value[port];
+    return _mouse_enabled == 0 ? joystick_potx_value[port] : 0xff;
 }
 
 static uint8_t joystick_read_poty(int port)
 {
-    return joystick_poty_value[port];
+    return _mouse_enabled == 0 ? joystick_poty_value[port] : 0xff;
 }
 #endif

--- a/third_party/vice-3.3/src/joyport/mouse.c
+++ b/third_party/vice-3.3/src/joyport/mouse.c
@@ -198,6 +198,15 @@ static uint8_t mouse_digital_val = 0;
 
 static uint8_t mouse_get_1351_x(int port)
 {
+#ifdef DEBUG_MOUSE
+    static int last_last_mouse_x = 0;
+
+    if (last_last_mouse_x != last_mouse_x) {
+        log_message(mouse_log, "mouse_get_1351_x port %d, last_mouse_x %u, last_mouse_x calc %u", 
+            port, (uint8_t)(last_mouse_x & 0xff), (uint8_t)((last_mouse_x & 0x7f) + 0x40));
+        last_last_mouse_x = last_mouse_x;
+    }
+#endif
     return (uint8_t)((last_mouse_x & 0x7f) + 0x40);
 }
 
@@ -1077,6 +1086,11 @@ static void mouse_button_left(int pressed)
 {
     uint8_t old_val = mouse_digital_val;
     uint8_t joypin = (((mouse_type == MOUSE_TYPE_PADDLE) || (mouse_type == MOUSE_TYPE_KOALAPAD)) ? 4 : 16);
+
+#ifdef DEBUG_MOUSE
+    log_message(mouse_log, "mouse_button_left mouse_type:%d, joypin:%d, new_x:%d new_y:%d, pressed:%d", 
+        mouse_type, joypin, (int16_t)mousedrv_get_x(), (int16_t)mousedrv_get_y(), pressed);
+#endif
 
     if (pressed) {
         mouse_digital_val |= joypin;

--- a/third_party/vice-3.3/src/joyport/mouse.c
+++ b/third_party/vice-3.3/src/joyport/mouse.c
@@ -198,20 +198,12 @@ static uint8_t mouse_digital_val = 0;
 
 static uint8_t mouse_get_1351_x(int port)
 {
-    if (_mouse_enabled) {
-        mouse_poll();
-        return (uint8_t)((last_mouse_x & 0x7f) + 0x40);
-    }
-    return 0xff;
+    return (uint8_t)((last_mouse_x & 0x7f) + 0x40);
 }
 
 static uint8_t mouse_get_1351_y(int port)
 {
-    if (_mouse_enabled) {
-        mouse_poll();
-        return (uint8_t)((last_mouse_y & 0x7f) + 0x40);
-    }
-    return 0xff;
+    return (uint8_t)((last_mouse_y & 0x7f) + 0x40);
 }
 
 /* --------------------------------------------------------- */

--- a/third_party/vice-3.3/src/sid/sid.c
+++ b/third_party/vice-3.3/src/sid/sid.c
@@ -132,6 +132,11 @@ static uint8_t sid_read_chip(uint16_t addr, int chipno)
     if (chipno == 0 && (addr == 0x19 || addr == 0x1a)) {
         if ((maincpu_clk ^ pot_cycle) & ~511) {
             pot_cycle = maincpu_clk & ~511; /* simplistic 512 cycle sampling */
+
+            if (_mouse_enabled) {
+                mouse_poll();
+            }
+
             val_pot_x = read_joyport_potx();
             val_pot_y = read_joyport_poty();
         }

--- a/third_party/vice-3.3/src/sid/sid.c
+++ b/third_party/vice-3.3/src/sid/sid.c
@@ -27,6 +27,7 @@
  *  02111-1307  USA.
  *
  */
+/* #define DEBUG_SID */
 
 #include "vice.h"
 
@@ -48,6 +49,13 @@
 #include "sound.h"
 #include "ssi2001.h"
 #include "types.h"
+#include "log.h"
+
+#ifdef DEBUG_SID
+#define DBG(_x_)  log_debug _x_
+#else
+#define DBG(_x_)
+#endif
 
 #ifdef RASPI_COMPILE
 int (*sid_job_func)(struct sound_s *psid, short *pbuf,
@@ -87,6 +95,11 @@ static int sid_enable, sid_engine_type = -1;
 #ifdef HAVE_MOUSE
 static CLOCK pot_cycle = 0;  /* pot sampling cycle */
 static uint8_t val_pot_x = 0xff, val_pot_y = 0xff; /* last sampling value */
+#endif
+
+/* Log descriptor.  */
+#ifdef DEBUG_SID
+static log_t sid_log = LOG_ERR;
 #endif
 
 uint8_t *sid_get_siddata(unsigned int channel)
@@ -139,6 +152,28 @@ static uint8_t sid_read_chip(uint16_t addr, int chipno)
 
             val_pot_x = read_joyport_potx();
             val_pot_y = read_joyport_poty();
+
+#ifdef DEBUG_SID
+            static uint8_t last_val_pot_x = 0;
+            static uint8_t last_val_pot_y = 0;
+            static uint8_t last_val_pot_x_2 = 0;
+            static uint8_t last_val_pot_y_2 = 0;
+
+            if (addr == 0x19 && ((val_pot_x != last_val_pot_x) || (val_pot_y != last_val_pot_y))) {
+                log_message(sid_log, "sid_read_chip 0x19 addr: 0x%02x, val_pot_x 0x%02x, val_pot_y 0x%02x", 
+                    addr, val_pot_x, val_pot_y);
+
+                last_val_pot_x = val_pot_x;
+                last_val_pot_y = val_pot_y;
+            }
+            if (addr == 0x1a && ((val_pot_x != last_val_pot_x_2) || (val_pot_y != last_val_pot_y_2))) {
+                log_message(sid_log, "sid_read_chip 0x1a addr: 0x%02x, val_pot_x 0x%02x, val_pot_y 0x%02x", 
+                    addr, val_pot_x, val_pot_y);
+
+                last_val_pot_x_2 = val_pot_x;
+                last_val_pot_y_2 = val_pot_y;
+            }
+#endif            
         }
         val = (addr == 0x19) ? val_pot_x : val_pot_y;
 


### PR DESCRIPTION
Fix for the mouse jumping while clicking issue #248.

Includes
- Two small general compile fixes
- Persist USB Gamepad pot values to setting.txt (enable workaround from menu)
- Port mouse_poll clean up code from Vice
- Add useful debug logging code for mouse diagnosis (disabled)
- Simple check to force 0xff response when the mouse is enabled from joystick read potx/y functions

