### PR TITLE
Fix teensy-resid crash and compile issues for Pi0

### DIFF
--- a/make_all.sh
+++ b/make_all.sh
@@ -175,6 +175,14 @@ fi
 # Vice
 cd $SRC_DIR/third_party/vice-3.3
 
+# Run autogen to ensure build system is up-to-date
+echo "Running autogen for VICE..."
+./autogen.sh
+if [ "$?" != "0" ]; then
+    echo "autogen failed!"
+    exit 1
+fi
+
 if [ "$BOARD" = "pi0" ]
 then
 # We have to configure resid even though we don't link it for pi0 to
@@ -217,6 +225,19 @@ if [ "$?" != "0" ]
 then
        exit
 fi
+
+# Build teensy-resid for pi0
+if [ "$BOARD" = "pi0" ]
+then
+cd teensy-resid
+make libresid.a
+if [ "$?" != "0" ]
+then
+       exit
+fi
+cd ..
+fi
+
 cd ..
 
 # These will fail

--- a/reset_repo.sh
+++ b/reset_repo.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "Resetting repository to clean state..."
+echo "This will remove all untracked files and revert all changes!"
+echo ""
+
+read -p "Do you want to continue? (y/N): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Operation cancelled."
+    exit 1
+fi
+
+echo ""
+
+# Clean and reset main repository
+echo "Cleaning main repository..."
+git clean -xfd
+git checkout .
+
+# Clean and reset all submodules
+echo "Cleaning submodules..."
+git submodule foreach --recursive 'git clean -xfd'
+git submodule foreach --recursive 'git checkout .'
+
+echo "Repository reset complete!"

--- a/third_party/vice-3.3/src/teensy-resid/sid.cc
+++ b/third_party/vice-3.3/src/teensy-resid/sid.cc
@@ -465,7 +465,7 @@ bool SID::set_sampling_parameters(double clock_freq, sampling_method method,
 				  double sample_freq, double pass_freq,
 				  double filter_scale)
 {
-   set_sampling_parameters((float)clock_freq, method,
+   return set_sampling_parameters((float)clock_freq, method,
                            (float)sample_freq, (float)pass_freq,
                            (float)filter_scale);
 }

--- a/third_party/vice-3.3/src/teensy-resid/siddefs.h
+++ b/third_party/vice-3.3/src/teensy-resid/siddefs.h
@@ -20,6 +20,46 @@
 #ifndef __SIDDEFS_H__
 #define __SIDDEFS_H__
 
+// Fix for missing __uint*_t types - define them BEFORE any system includes
+// But check if they're already defined by system headers first
+#ifndef __uint8_t_defined
+#ifndef __uint8_t
+typedef unsigned char __uint8_t;
+#define __uint8_t_defined
+#endif
+#endif
+
+#ifndef __uint32_t_defined
+#ifndef __uint32_t
+// Use the same type as the system (unsigned long for ARM)
+typedef unsigned long __uint32_t;
+#define __uint32_t_defined
+#endif
+#endif
+
+#ifndef __uint64_t_defined
+#ifndef __uint64_t
+typedef unsigned long long __uint64_t;
+#define __uint64_t_defined
+#endif
+#endif
+
+// Also define the standard types to prevent conflicts
+#ifndef _UINT8_T_DECLARED
+typedef __uint8_t uint8_t;
+#define _UINT8_T_DECLARED
+#endif
+
+#ifndef _UINT32_T_DECLARED
+typedef __uint32_t uint32_t;
+#define _UINT32_T_DECLARED
+#endif
+
+#ifndef _UINT64_T_DECLARED
+typedef __uint64_t uint64_t;
+#define _UINT64_T_DECLARED
+#endif
+
 // Define bool, true, and false for C++ compilers that lack these keywords.
 #define RESID_HAVE_BOOL 1
 
@@ -57,7 +97,8 @@ const bool false = 0;
 // (GNU Coding Standards: Portability between CPUs), so this should be
 // a valid assumption.
 
-#include <stdint.h>
+// Don't include stdint.h as it causes type conflicts
+// #include <stdint.h>
 typedef unsigned int reg4;
 typedef unsigned int reg8;
 typedef unsigned int reg12;


### PR DESCRIPTION
When trying to build for Pi Zero (Pi0) I ran into compile problems, and then a crash on start up. Proposed pull request for this issue: https://github.com/randyrossi/bmc64/issues/302

The compile issues were related to the missing types and redundant header which I updated to the siddefs.h header in teensy-resid so that the changes only affected that module and Pi0 build. Adding these fixed the compile problems.

I also updated the make_all.sh to build the teensy-resid during a build for Pi0 as that was missing, and added a call to the autogen.sh for vice to make it easier to compile from a clean repo.

Once it compiled I got a crash on startup which is shown in the log in this issue: https://github.com/randyrossi/bmc64/issues/302 

This turned out to be a problem with the return of the call from set_sampling_parameters when it was called from resid.cc line 253, into the built teensy-resid library. It was missing the return value, which caused the startup crash. 

I added a seprate script reset_repo.sh as a simple way to reset all the repo and submodule back to a clean state, to make it easier to test building from a directly checked out respository. Not needed in the pull request but I found it nice to have.
