### PR TITLE
Support drive-snapshot for 4 drives, tde per drive and backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,3 +461,18 @@
   * Correct network connect message when switch a single microSD card between different models of Raspberry Pi
   * Back port RTC code from Vice 3.10 to set the correct time in CMD-HD images
   * Time improvements and fixes allow C64 OS to start with the correct time set 
+
+## 5.0.0 RC
+  * Fix placement of the CRT files in the building of the SD Card
+  * Update NETWORKING.md with details on firmware files requirement
+  * Add specific WiFi firmware missing warning and fix startup crash with missing firmware
+  * Improve logging on snapshots
+  * Fix snapshot write failure when networking is active by activating CARTRIDGE_TURBO232 snapshot code
+  * Add github build workflow
+  * Fix possible overflow bug in vdrive snapshot
+  * Port drive snapshots to use per-drive TDE for all four drives
+  * Implement simple CMDHD support in snapshots
+  * Fix version for creation of p64images in snapshots
+  * Implement per-drive TDE in drive snapshots
+  * Support backwards compatibility for old drive snapshot versions
+  * Fix TDE set to zero bug when saving settings after a snapshot restore

--- a/third_party/common/menu.c
+++ b/third_party/common/menu.c
@@ -57,7 +57,7 @@
 
 extern void reboot(void);
 
-#define VERSION_STRING "5.0.0"
+#define VERSION_STRING "5.0.0 RC"
 
 #ifdef RASPI_LITE
 #define VARIANT_STRING "-Lite"

--- a/third_party/vice-3.3/src/arch/raspi/vice_api.c
+++ b/third_party/vice-3.3/src/arch/raspi/vice_api.c
@@ -85,31 +85,40 @@ struct menu_item *adapter_type_item;
 
 void raspi_keymap_changed(int, int, signed long);
 
+// SID resource setters mark the engine dirty even when the value is unchanged.
+// Avoid reinitializing state that was just restored from a snapshot.
+static void set_int_if_changed(const char *resource, int value) {
+  int current;
+  if (resources_get_int(resource, &current) < 0 || current != value) {
+    resources_set_int(resource, value);
+  }
+}
+
 // Make sure SID options are sane for this model
 static void check_sid_options() {
   int value;
   resources_get_int("SidResidSampling", &value);
   // For less capable Pi's, we force fast sampling.
   if (circle_get_model() < 3) {
-     resources_set_int("SidResidSampling", SID_RESID_SAMPLING_FAST);
+     set_int_if_changed("SidResidSampling", SID_RESID_SAMPLING_FAST);
   } else if (circle_get_model() < 4) {
      if (value == SID_RESID_SAMPLING_RESAMPLING) {
-       resources_set_int( "SidResidSampling",
-              SID_RESID_SAMPLING_FAST_RESAMPLING);
+       set_int_if_changed("SidResidSampling",
+                          SID_RESID_SAMPLING_FAST_RESAMPLING);
      }
   }
 
   // These can never change and must match the logic in
   // viceemulatorcore.cpp.
   //if (circle_get_arm_clock() < 1400000000) {
-     resources_set_int("SidResidPassband", 60);
-     resources_set_int("SidResid8580Passband", 60);
+     set_int_if_changed("SidResidPassband", 60);
+     set_int_if_changed("SidResid8580Passband", 60);
   //} else {
   //   resources_set_int("SidResidPassband", 90);
   //   resources_set_int("SidResid8580Passband", 90);
   //}
-  resources_set_int("SidResidGain", 97);
-  resources_set_int("SidResid8580Gain", 97);
+  set_int_if_changed("SidResidGain", 97);
+  set_int_if_changed("SidResid8580Gain", 97);
 
   // When dual sid is enabled, SidStereo=1, SoundOutput=2 and
   // the audio driver must be configured for 2 channel output.
@@ -124,14 +133,14 @@ static void check_sid_options() {
   if (circle_get_model() >= 2) {
      resources_get_int("SidStereo", &value);
      if (value > 0) {
-        resources_set_int("SoundOutput", 2);
+        set_int_if_changed("SoundOutput", 2);
      } else {
-        resources_set_int("SoundOutput", 1);
+        set_int_if_changed("SoundOutput", 1);
      }
   } else {
      // Always mono for < Pi2
-     resources_set_int("SidStereo", 0);
-     resources_set_int("SoundOutput", 1);
+      set_int_if_changed("SidStereo", 0);
+      set_int_if_changed("SoundOutput", 1);
   }
 }
 

--- a/third_party/vice-3.3/src/drive/drive-snapshot.c
+++ b/third_party/vice-3.3/src/drive/drive-snapshot.c
@@ -58,7 +58,7 @@
 #include "p64.h"
 
 
-/* Currently the drive snapshot only handles 2 drives.  */
+/* The drive snapshot handles all DRIVE_NUM drives. */
 
 /* Logging.  */
 static log_t drive_snapshot_log = LOG_ERR;
@@ -78,34 +78,36 @@ This is the format of the DRIVE snapshot module.
 Name                 Type   Size   Description
 
 SyncFactor           DWORD  1      sync factor main cpu <-> drive cpu
+TrueEmulation        BYTE   4      true drive emulation per drive
 
-Accum                DWORD  2
-AttachClk            CLOCK  2      write protect handling on attach
-BitsMoved            DWORD  2      number of bits moved since last access
-ByteReady            BYTE   2      flag: Byte ready
-ClockFrequency       BYTE   2      current clock frequency
-CurrentHalfTrack     WORD   2      current half track of the r/w head
-DetachClk            CLOCK  2      write protect handling on detach
-DiskID1              BYTE   2      disk ID1
-DiskID2              BYTE   2      disk ID2
-ExtendImagePolicy    BYTE   2      Is extending the disk image allowed
-FinishByte           BYTE   2      flag: Mode changed, finish byte
-GCRHeadOffset        DWORD  2      offset from the begin of the track
-GCRRead              BYTE   2      next value to read from disk
-GCRWriteValue        BYTE   2      next value to write to disk
-IdlingMethod         BYTE   2      What idle methode do we use
-LastMode             BYTE   2      flag: Was the last mode read or write
-ParallelCableEnabled BYTE   2      flag: Is the parallel cable enabed
-ReadOnly             BYTE   2      flag: This disk is read only
-RotationLastClk      CLOCK  2
-RotationTablePtr     DWORD  2      pointer to the rotation table
+Accum                DWORD  4
+AttachClk            CLOCK  4      write protect handling on attach
+BitsMoved            DWORD  4      number of bits moved since last access
+ByteReady            BYTE   4      flag: Byte ready
+ClockFrequency       BYTE   4      current clock frequency
+CurrentHalfTrack     WORD   4      current half track of the r/w head
+DetachClk            CLOCK  4      write protect handling on detach
+DiskID1              BYTE   4      disk ID1
+DiskID2              BYTE   4      disk ID2
+ExtendImagePolicy    BYTE   4      Is extending the disk image allowed
+FinishByte           BYTE   4      flag: Mode changed, finish byte
+GCRHeadOffset        DWORD  4      offset from the begin of the track
+GCRRead              BYTE   4      next value to read from disk
+GCRWriteValue        BYTE   4      next value to write to disk
+IdlingMethod         BYTE   4      What idle methode do we use
+LastMode             BYTE   4      flag: Was the last mode read or write
+ParallelCableEnabled BYTE   4      flag: Is the parallel cable enabed
+ReadOnly             BYTE   4      flag: This disk is read only
+RotationLastClk      CLOCK  4
+RotationTablePtr     DWORD  4      pointer to the rotation table
                                    (offset to the rotation table is saved)
-Type                 DWORD  2      drive type
+Type                 DWORD  4      drive type
 
 */
 
+/* Version 1.6 adds the per-drive TrueEmulation bytes after SyncFactor. */
 #define DRIVE_SNAP_MAJOR 1
-#define DRIVE_SNAP_MINOR 5
+#define DRIVE_SNAP_MINOR 6
 
 int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
 {
@@ -114,18 +116,25 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
     snapshot_module_t *m;
     uint32_t rotation_table_ptr[DRIVE_NUM];
     uint8_t GCR_image[DRIVE_NUM], P64_image[DRIVE_NUM];
-    int drive_true_emulation;
+    int drive_true_emulation[DRIVE_NUM];
+    int any_true_emulation = 0;
     int sync_factor;
     drive_t *drive;
 
-    resources_get_int("DriveTrueEmulation", &drive_true_emulation);
+    /* A DRIVE module is needed whenever any hardware-emulated unit is active. */
+    for (i = 0; i < DRIVE_NUM; i++) {
+        if (resources_get_int_sprintf("Drive%iTrueEmulation",
+                                      &drive_true_emulation[i], i + 8) < 0) {
+            return -1;
+        }
+        any_true_emulation |= drive_true_emulation[i];
+    }
 
-    //if (vdrive_snapshot_module_write(s, drive_true_emulation ? 10 : 8) < 0) {
     if (vdrive_snapshot_module_write(s) < 0) { // VDRIVE_EFFORT
         return -1;
     }
 
-    if (!drive_true_emulation) {
+    if (!any_true_emulation) {
         return 0;
     }
 
@@ -152,6 +161,14 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
             snapshot_module_close(m);
         }
         return -1;
+    }
+
+    /* Keep this immediately after SyncFactor so the 1.6 layout is explicit. */
+    for (i = 0; i < DRIVE_NUM; i++) {
+        if (SMW_B(m, (uint8_t)drive_true_emulation[i]) < 0) {
+            snapshot_module_close(m);
+            return -1;
+        }
     }
 
     for (i = 0; i < DRIVE_NUM; i++) {
@@ -238,18 +255,20 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
 
     for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
-        if (drive->enable) {
-            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000 ||
-                drive->type == DRIVE_TYPE_CMDHD) {
+        if (drive_true_emulation[i] && drive->enable) {
+            /* CMDHD CPU snapshots are not readable: their writer appends 64K
+               of RAM which the 65C02 reader does not consume. */
+            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
                 if (drivecpu65c02_snapshot_write_module(drive_context[i], s) < 0) {
                     return -1;
                 }
-            } else {
+            } else if (drive->type != DRIVE_TYPE_CMDHD) {
                 if (drivecpu_snapshot_write_module(drive_context[i], s) < 0) {
                     return -1;
                 }
             }
-            if (machine_drive_snapshot_write(drive_context[i], s) < 0) {
+            if (drive->type != DRIVE_TYPE_CMDHD
+                && machine_drive_snapshot_write(drive_context[i], s) < 0) {
                 return -1;
             }
         }
@@ -276,7 +295,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
 
     for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
-        if (save_roms && drive->enable) {
+        if (save_roms && drive_true_emulation[i] && drive->enable) {
             if (driverom_snapshot_write(s, drive) < 0) {
                 return -1;
             }
@@ -290,13 +309,14 @@ int drive_snapshot_read_module(snapshot_t *s)
 {
     uint8_t major_version, minor_version;
     int i;
+    int snapshot_drive_count;
     snapshot_module_t *m;
     char snap_module_name[] = "DRIVE";
     uint32_t rotation_table_ptr[DRIVE_NUM];
     CLOCK attach_clk[DRIVE_NUM];
     CLOCK detach_clk[DRIVE_NUM];
     CLOCK attach_detach_clk[DRIVE_NUM];
-    int drive_true_emulation;
+    int drive_true_emulation[DRIVE_NUM] = { 0 };
     int sync_factor;
     drive_t *drive;
     int dummy;
@@ -305,8 +325,15 @@ int drive_snapshot_read_module(snapshot_t *s)
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
     if (m == NULL) {
-        /* If this module is not found true emulation is off.  */
-        resources_set_int("DriveTrueEmulation", 0);
+          /* No drive state was saved, so preserve the current TDE configuration.
+
+              Disabling TDE here can persist after a failed or drive-less snapshot
+              load and unintentionally leave a previously enabled drive unusable.
+              So this original code below is now commented out and the TDE state is preserved instead.
+          for (i = 0; i < DRIVE_NUM; i++) {
+                resources_set_int_sprintf("Drive%iTrueEmulation", 0, i + 8);
+          }
+            */
         return 0;
     }
 
@@ -319,23 +346,31 @@ int drive_snapshot_read_module(snapshot_t *s)
         return -1;
     }
 
-    /* reject snapshot modules older than what we can handle (the snapshot is too old) */
-    if (snapshot_version_is_smaller(major_version, minor_version, DRIVE_SNAP_MAJOR, DRIVE_SNAP_MINOR)) {
-        snapshot_set_error(SNAPSHOT_MODULE_INCOMPATIBLE);
-        snapshot_module_close(m);
-        return -1;
-    }
-
-    /* If this module exists true emulation is enabled.  */
-    /* XXX drive_true_emulation = 1 */
-    resources_set_int("DriveTrueEmulation", 1);
-
     if (SMR_DW_INT(m, &sync_factor) < 0) {
         snapshot_module_close(m);
         return -1;
     }
 
-    for (i = 0; i < DRIVE_NUM; i++) {
+    if (snapshot_version_is_equal(major_version, minor_version, 1, 6)) {
+        /* Version 1.6 stores TDE state for all four drive contexts. */
+        snapshot_drive_count = DRIVE_NUM;
+        for (i = 0; i < DRIVE_NUM; i++) {
+            if (SMR_B_INT(m, &drive_true_emulation[i]) < 0) {
+                snapshot_module_close(m);
+                return -1;
+            }
+        }
+    } else if (snapshot_version_is_equal(major_version, minor_version, 1, 5)) {
+        /* Version 1.5 has four contexts but predates per-drive TDE storage. */
+        snapshot_drive_count = DRIVE_NUM;
+    } else {
+        /* Versions 1.0-1.4 contain only the original drive 8 and 9 contexts. */
+        snapshot_drive_count = 2;
+        drive_true_emulation[0] = 1;
+        drive_true_emulation[1] = 1;
+    }
+
+    for (i = 0; i < snapshot_drive_count; i++) {
         drive = drive_context[i]->drive;
 
         /* Partially read 1.0 snapshots */
@@ -532,13 +567,13 @@ int drive_snapshot_read_module(snapshot_t *s)
     }
 
     /* this one is new, so don't test so stay compatible with old snapshots */
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         drive = drive_context[i]->drive;
         SMR_DW(m, &(attach_detach_clk[i]));
     }
 
     /* these are even newer */
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         drive = drive_context[i]->drive;
         SMR_B_INT(m, (int *)&(drive->byte_ready_edge));
         SMR_B_INT(m, (int *)&(drive->byte_ready_active));
@@ -693,26 +728,41 @@ int drive_snapshot_read_module(snapshot_t *s)
         parallel_cable_drive_write(i, 0xff, PARALLEL_WRITE, 1);
     }
 
+    if (snapshot_version_is_equal(major_version, minor_version, 1, 5)) {
+        /* Infer the missing 1.5 TDE state from each restored drive type. */
+        for (i = 0; i < DRIVE_NUM; i++) {
+            drive_true_emulation[i] = drive_context[i]->drive->type != DRIVE_TYPE_NONE;
+        }
+    }
+
     for (i = 0; i < DRIVE_NUM; i++) {
+        if (resources_set_int_sprintf("Drive%iTrueEmulation",
+                                      drive_true_emulation[i], i + 8) < 0) {
+            return -1;
+        }
+    }
+
+    /* CPU snapshot modules are present only for drives with TDE enabled. */
+    for (i = 0; i < snapshot_drive_count; i++) {
         drive = drive_context[i]->drive;
         if (drive->enable) {
-            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000 ||
-                drive->type == DRIVE_TYPE_CMDHD) {
+            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
                 if (drivecpu65c02_snapshot_read_module(drive_context[i], s) < 0) {
                     return -1;
                 }
-            } else {
+            } else if (drive->type != DRIVE_TYPE_CMDHD) {
                 if (drivecpu_snapshot_read_module(drive_context[i], s) < 0) {
                     return -1;
                 }
             }
-            if (machine_drive_snapshot_read(drive_context[i], s) < 0) {
+            if (drive->type != DRIVE_TYPE_CMDHD
+                && machine_drive_snapshot_read(drive_context[i], s) < 0) {
                 return -1;
             }
         }
     }
 
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         if (drive_snapshot_read_image_module(s, i) < 0
             || drive_snapshot_read_gcrimage_module(s, i) < 0
             || drive_snapshot_read_p64image_module(s, i) < 0) {
@@ -720,13 +770,13 @@ int drive_snapshot_read_module(snapshot_t *s)
         }
     }
 
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         if (driverom_snapshot_read(s, drive_context[i]->drive) < 0) {
             return -1;
         }
     }
 
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         drive = drive_context[i]->drive;
         if (drive->type != DRIVE_TYPE_NONE) {
             drive_enable(drive_context[i]);
@@ -736,7 +786,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         }
     }
 
-    for (i = 0; i < DRIVE_NUM; i++) {
+    for (i = 0; i < snapshot_drive_count; i++) {
         int side = 0;
         drive = drive_context[i]->drive;
         if (drive->type == DRIVE_TYPE_1570
@@ -760,9 +810,6 @@ int drive_snapshot_read_module(snapshot_t *s)
     iec_update_ports_embedded();
     drive_update_ui_status();
 
-    resources_get_int("DriveTrueEmulation", &drive_true_emulation);
-
-    //if (vdrive_snapshot_module_read(s, drive_true_emulation ? 10 : 8) < 0) {
     if (vdrive_snapshot_module_read(s) < 0) { // VDRIVE_EFFORT
         return -1;
     }

--- a/third_party/vice-3.3/src/drive/drive-snapshot.c
+++ b/third_party/vice-3.3/src/drive/drive-snapshot.c
@@ -970,7 +970,7 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
         }
     }
 
-    vdrive_bam_reread_bam(dnr + 8);
+    //vdrive_bam_reread_bam(dnr + 8);// VDRIVE_EFFORT
 
     snapshot_module_close(m);
     m = NULL;

--- a/third_party/vice-3.3/src/drive/drive-snapshot.c
+++ b/third_party/vice-3.3/src/drive/drive-snapshot.c
@@ -1130,8 +1130,8 @@ static int drive_snapshot_write_p64image_module(snapshot_t *s, unsigned int dnr)
     drive = drive_context[dnr]->drive;
     sprintf(snap_module_name, "P64IMAGE%u", dnr);
 
-    m = snapshot_module_create(s, snap_module_name, GCRIMAGE_SNAP_MAJOR,
-                               GCRIMAGE_SNAP_MINOR);
+    m = snapshot_module_create(s, snap_module_name, P64IMAGE_SNAP_MAJOR,
+                               P64IMAGE_SNAP_MINOR);
     if (m == NULL) {
         return -1;
     }

--- a/third_party/vice-3.3/src/drive/drive-snapshot.c
+++ b/third_party/vice-3.3/src/drive/drive-snapshot.c
@@ -105,7 +105,7 @@ Type                 DWORD  2      drive type
 */
 
 #define DRIVE_SNAP_MAJOR 1
-#define DRIVE_SNAP_MINOR 4
+#define DRIVE_SNAP_MINOR 5
 
 int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
 {
@@ -113,7 +113,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
     char snap_module_name[] = "DRIVE";
     snapshot_module_t *m;
     uint32_t rotation_table_ptr[DRIVE_NUM];
-    uint8_t GCR_image[4], P64_image[4];
+    uint8_t GCR_image[DRIVE_NUM], P64_image[DRIVE_NUM];
     int drive_true_emulation;
     int sync_factor;
     drive_t *drive;
@@ -133,7 +133,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
 
     rotation_table_get(rotation_table_ptr);
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         GCR_image[i] = (drive->GCR_image_loaded == 0 || !save_disks) ? 0 : 1;
         P64_image[i] = (drive->P64_image_loaded == 0 || !save_disks) ? 0 : 1;
@@ -154,8 +154,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
         return -1;
     }
 
-    /* TODO: NUM_DRIVES drives instead of 2 */
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (0
             || SMW_DW(m, (uint32_t)(drive->attach_clk)) < 0
@@ -208,7 +207,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
     }
 
     /* new snapshot members */
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (0
             || SMW_DW(m, (uint32_t)(drive->attach_detach_clk)) < 0
@@ -220,7 +219,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
         }
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (0
             || SMW_B(m, (uint8_t)(drive->byte_ready_edge)) < 0
@@ -237,7 +236,7 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
         return -1;
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (drive->enable) {
             if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
@@ -256,35 +255,25 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
     }
 
     if (save_disks) {
-        if (GCR_image[0] > 0) {
-            if (drive_snapshot_write_gcrimage_module(s, 0) < 0) {
-                return -1;
-            }
-        } else if (P64_image[0] > 0) {
-            if (drive_snapshot_write_p64image_module(s, 0) < 0) {
-                return -1;
-            }
-        } else {
-            if (drive_snapshot_write_image_module(s, 0) < 0) {
-                return -1;
-            }
-        }
-        if (GCR_image[1] > 0) {
-            if (drive_snapshot_write_gcrimage_module(s, 1) < 0) {
-                return -1;
-            }
-        } else if (P64_image[1] > 0) {
-            if (drive_snapshot_write_p64image_module(s, 1) < 0) {
-                return -1;
-            }
-        } else {
-            if (drive_snapshot_write_image_module(s, 1) < 0) {
-                return -1;
+        int d;
+        for (d = 0; d < DRIVE_NUM; d++) {
+            if (GCR_image[d] > 0) {
+                if (drive_snapshot_write_gcrimage_module(s, d) < 0) {
+                    return -1;
+                }
+            } else if (P64_image[d] > 0) {
+                if (drive_snapshot_write_p64image_module(s, d) < 0) {
+                    return -1;
+                }
+            } else {
+                if (drive_snapshot_write_image_module(s, d) < 0) {
+                    return -1;
+                }
             }
         }
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (save_roms && drive->enable) {
             if (driverom_snapshot_write(s, drive) < 0) {
@@ -322,11 +311,18 @@ int drive_snapshot_read_module(snapshot_t *s)
 
     drive_gcr_data_writeback_all();
 
-    if (major_version > DRIVE_SNAP_MAJOR || minor_version > DRIVE_SNAP_MINOR) {
-        log_error(drive_snapshot_log,
-                  "Snapshot module version (%d.%d) newer than %d.%d.",
-                  major_version, minor_version,
-                  DRIVE_SNAP_MAJOR, DRIVE_SNAP_MINOR);
+    /* reject snapshot modules newer than what we can handle (this VICE is too old) */
+    if (snapshot_version_is_bigger(major_version, minor_version, DRIVE_SNAP_MAJOR, DRIVE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_HIGHER_VERSION);
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    /* reject snapshot modules older than what we can handle (the snapshot is too old) */
+    if (snapshot_version_is_smaller(major_version, minor_version, DRIVE_SNAP_MAJOR, DRIVE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_INCOMPATIBLE);
+        snapshot_module_close(m);
+        return -1;
     }
 
     /* If this module exists true emulation is enabled.  */
@@ -338,12 +334,11 @@ int drive_snapshot_read_module(snapshot_t *s)
         return -1;
     }
 
-    /* TODO: NUM_DRIVES drives instead of 2 */
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
 
         /* Partially read 1.0 snapshots */
-        if (major_version == 1 && minor_version == 0) {
+        if (snapshot_version_is_equal(major_version, minor_version, 1, 0)) {
             if (0
                 || SMR_DW_UL(m, &(drive->snap_accum)) < 0
                 || SMR_DW(m, &(attach_clk[i])) < 0
@@ -372,7 +367,7 @@ int drive_snapshot_read_module(snapshot_t *s)
             }
 
             /* Partially read 1.1 snapshots */
-        } else if (major_version == 1 && minor_version == 1) {
+        } else if (snapshot_version_is_equal(major_version, minor_version, 1, 1)) {
             if (0
                 || SMR_DW(m, &(attach_clk[i])) < 0
                 || SMR_B_INT(m, (int *)&(drive->byte_ready_level)) < 0
@@ -404,7 +399,7 @@ int drive_snapshot_read_module(snapshot_t *s)
             }
 
             /* Partially read 1.2 snapshots */
-        } else if (major_version == 1 && minor_version == 2) {
+        } else if (snapshot_version_is_equal(major_version, minor_version, 1, 2)) {
             if (0
                 || SMR_DW(m, &(attach_clk[i])) < 0
                 || SMR_B_INT(m, (int *)&(drive->byte_ready_level)) < 0
@@ -445,7 +440,7 @@ int drive_snapshot_read_module(snapshot_t *s)
                 snapshot_module_close(m);
                 return -1;
             }
-        } else if (major_version == 1 && minor_version == 3) {
+        } else if (snapshot_version_is_equal(major_version, minor_version, 1, 3)) {
             if (0
                 || SMR_DW(m, &(attach_clk[i])) < 0
                 || SMR_B_INT(m, (int *)&(drive->byte_ready_level)) < 0
@@ -536,13 +531,13 @@ int drive_snapshot_read_module(snapshot_t *s)
     }
 
     /* this one is new, so don't test so stay compatible with old snapshots */
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         SMR_DW(m, &(attach_detach_clk[i]));
     }
 
     /* these are even newer */
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         SMR_B_INT(m, (int *)&(drive->byte_ready_edge));
         SMR_B_INT(m, (int *)&(drive->byte_ready_active));
@@ -620,13 +615,80 @@ int drive_snapshot_read_module(snapshot_t *s)
             return -1;
     }
 
+    drive = drive_context[2]->drive;
+    switch (drive->type) {
+        case DRIVE_TYPE_1540:
+        case DRIVE_TYPE_1541:
+        case DRIVE_TYPE_1541II:
+        case DRIVE_TYPE_1551:
+        case DRIVE_TYPE_1570:
+        case DRIVE_TYPE_1571:
+        case DRIVE_TYPE_1571CR:
+        case DRIVE_TYPE_1581:
+        case DRIVE_TYPE_2000:
+        case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_2031:
+        case DRIVE_TYPE_1001:
+        case DRIVE_TYPE_2040:
+        case DRIVE_TYPE_3040:
+        case DRIVE_TYPE_4040:
+        case DRIVE_TYPE_8050:
+        case DRIVE_TYPE_8250:
+            drive->enable = 1;
+            machine_drive_rom_setup_image(2);
+            drivemem_init(drive_context[2], drive->type);
+            resources_set_int("Drive10IdleMethod", drive->idling_method);
+            driverom_initialize_traps(drive);
+            drive_set_active_led_color(drive->type, 0);
+            machine_bus_status_drivetype_set(10, 1);
+            break;
+        case DRIVE_TYPE_NONE:
+            drive_disable(drive_context[2]);
+            machine_bus_status_drivetype_set(10, 0);
+            break;
+        default:
+            return -1;
+    }
+
+    drive = drive_context[3]->drive;
+    switch (drive->type) {
+        case DRIVE_TYPE_1540:
+        case DRIVE_TYPE_1541:
+        case DRIVE_TYPE_1541II:
+        case DRIVE_TYPE_1551:
+        case DRIVE_TYPE_1570:
+        case DRIVE_TYPE_1571:
+        case DRIVE_TYPE_1581:
+        case DRIVE_TYPE_2000:
+        case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_2031:
+        case DRIVE_TYPE_1001:
+            /* drive 1 does not allow dual disk drive */
+            drive->enable = 1;
+            machine_drive_rom_setup_image(3);
+            drivemem_init(drive_context[3], drive->type);
+            resources_set_int("Drive11IdleMethod", drive->idling_method);
+            driverom_initialize_traps(drive);
+            drive_set_active_led_color(drive->type, 1);
+            machine_bus_status_drivetype_set(11, 1);
+            break;
+        case DRIVE_TYPE_NONE:
+        case DRIVE_TYPE_8050:
+        case DRIVE_TYPE_8250:
+            drive_disable(drive_context[3]);
+            machine_bus_status_drivetype_set(11, 0);
+            break;
+        default:
+            return -1;
+    }
+
     /* Clear parallel cable before undumping parallel port values.  */
     for (i = 0; i < DRIVE_PC_NUM; i++) {
         parallel_cable_drive_write(i, 0xff, PARALLEL_WRITE, 0);
         parallel_cable_drive_write(i, 0xff, PARALLEL_WRITE, 1);
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (drive->enable) {
             if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
@@ -644,24 +706,21 @@ int drive_snapshot_read_module(snapshot_t *s)
         }
     }
 
-    if (drive_snapshot_read_image_module(s, 0) < 0
-        || drive_snapshot_read_gcrimage_module(s, 0) < 0
-        || drive_snapshot_read_p64image_module(s, 0) < 0) {
-        return -1;
-    }
-    if (drive_snapshot_read_image_module(s, 1) < 0
-        || drive_snapshot_read_gcrimage_module(s, 1) < 0
-        || drive_snapshot_read_p64image_module(s, 1) < 0) {
-        return -1;
-    }
-    if (driverom_snapshot_read(s, drive_context[0]->drive) < 0) {
-        return -1;
-    }
-    if (driverom_snapshot_read(s, drive_context[1]->drive) < 0) {
-        return -1;
+    for (i = 0; i < DRIVE_NUM; i++) {
+        if (drive_snapshot_read_image_module(s, i) < 0
+            || drive_snapshot_read_gcrimage_module(s, i) < 0
+            || drive_snapshot_read_p64image_module(s, i) < 0) {
+            return -1;
+        }
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
+        if (driverom_snapshot_read(s, drive_context[i]->drive) < 0) {
+            return -1;
+        }
+    }
+
+    for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (drive->type != DRIVE_TYPE_NONE) {
             drive_enable(drive_context[i]);
@@ -671,7 +730,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         }
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DRIVE_NUM; i++) {
         int side = 0;
         drive = drive_context[i]->drive;
         if (drive->type == DRIVE_TYPE_1570
@@ -733,9 +792,9 @@ static int drive_snapshot_write_image_module(snapshot_t *s, unsigned int dnr)
     drive = drive_context[dnr]->drive;
 
     if (drive->image == NULL) {
-        sprintf(snap_module_name, "NOIMAGE%i", dnr);
+        sprintf(snap_module_name, "NOIMAGE%u", dnr);
     } else {
-        sprintf(snap_module_name, "IMAGE%i", dnr);
+        sprintf(snap_module_name, "IMAGE%u", dnr);
     }
 
     m = snapshot_module_create(s, snap_module_name, IMAGE_SNAP_MAJOR,
@@ -795,7 +854,7 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
 
     drive = drive_context[dnr]->drive;
 
-    sprintf(snap_module_name, "NOIMAGE%i", dnr);
+    sprintf(snap_module_name, "NOIMAGE%u", dnr);
 
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
@@ -805,7 +864,7 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
         return 0;
     }
 
-    sprintf(snap_module_name, "IMAGE%i", dnr);
+    sprintf(snap_module_name, "IMAGE%u", dnr);
 
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
@@ -813,11 +872,18 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
         return 0;
     }
 
-    if (major_version > IMAGE_SNAP_MAJOR || minor_version > IMAGE_SNAP_MINOR) {
-        log_error(drive_snapshot_log,
-                  "Snapshot module version (%d.%d) newer than %d.%d.",
-                  major_version, minor_version,
-                  IMAGE_SNAP_MAJOR, IMAGE_SNAP_MINOR);
+    /* reject snapshot modules newer than what we can handle (this VICE is too old) */
+    if (snapshot_version_is_bigger(major_version, minor_version, IMAGE_SNAP_MAJOR, IMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_HIGHER_VERSION);
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    /* reject snapshot modules older than what we can handle (the snapshot is too old) */
+    if (snapshot_version_is_smaller(major_version, minor_version, IMAGE_SNAP_MAJOR, IMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_INCOMPATIBLE);
+        snapshot_module_close(m);
+        return -1;
     }
 
     if (SMR_W(m, &word) < 0) {
@@ -895,7 +961,7 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
         }
     }
 
-    //vdrive_bam_reread_bam(dnr + 8); // VDRIVE_EFFORT
+    vdrive_bam_reread_bam(dnr + 8);
 
     snapshot_module_close(m);
     m = NULL;
@@ -919,7 +985,7 @@ static int drive_snapshot_write_gcrimage_module(snapshot_t *s, unsigned int dnr)
     uint32_t num_half_tracks, track_size;
 
     drive = drive_context[dnr]->drive;
-    sprintf(snap_module_name, "GCRIMAGE%i", dnr);
+    sprintf(snap_module_name, "GCRIMAGE%u", dnr);
 
     m = snapshot_module_create(s, snap_module_name, GCRIMAGE_SNAP_MAJOR,
                                GCRIMAGE_SNAP_MINOR);
@@ -965,7 +1031,7 @@ static int drive_snapshot_read_gcrimage_module(snapshot_t *s, unsigned int dnr)
     uint32_t num_half_tracks, track_size;
 
     drive = drive_context[dnr]->drive;
-    sprintf(snap_module_name, "GCRIMAGE%i", dnr);
+    sprintf(snap_module_name, "GCRIMAGE%u", dnr);
 
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
@@ -973,15 +1039,19 @@ static int drive_snapshot_read_gcrimage_module(snapshot_t *s, unsigned int dnr)
         return 0;
     }
 
-    if (major_version != GCRIMAGE_SNAP_MAJOR
-        || minor_version != GCRIMAGE_SNAP_MINOR) {
-        log_error(drive_snapshot_log,
-                  "Snapshot module version (%d.%d) not supported.",
-                  major_version, minor_version);
+    /* reject snapshot modules newer than what we can handle (this VICE is too old) */
+    if (snapshot_version_is_bigger(major_version, minor_version, GCRIMAGE_SNAP_MAJOR, GCRIMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_HIGHER_VERSION);
         snapshot_module_close(m);
         return -1;
     }
 
+    /* reject snapshot modules older than what we can handle (the snapshot is too old) */
+    if (snapshot_version_is_smaller(major_version, minor_version, GCRIMAGE_SNAP_MAJOR, GCRIMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_INCOMPATIBLE);
+        snapshot_module_close(m);
+        return -1;
+    }
 
     if (0
         || SMR_DW(m, &num_half_tracks) < 0
@@ -1049,7 +1119,7 @@ static int drive_snapshot_write_p64image_module(snapshot_t *s, unsigned int dnr)
     PP64Image P64Image;
 
     drive = drive_context[dnr]->drive;
-    sprintf(snap_module_name, "P64IMAGE%i", dnr);
+    sprintf(snap_module_name, "P64IMAGE%u", dnr);
 
     m = snapshot_module_create(s, snap_module_name, GCRIMAGE_SNAP_MAJOR,
                                GCRIMAGE_SNAP_MINOR);
@@ -1103,7 +1173,7 @@ static int drive_snapshot_read_p64image_module(snapshot_t *s, unsigned int dnr)
     uint32_t size;
 
     drive = drive_context[dnr]->drive;
-    sprintf(snap_module_name, "P64IMAGE%i", dnr);
+    sprintf(snap_module_name, "P64IMAGE%u", dnr);
 
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
@@ -1120,12 +1190,18 @@ static int drive_snapshot_read_p64image_module(snapshot_t *s, unsigned int dnr)
         return -1;
     }
 
-    if (major_version > P64IMAGE_SNAP_MAJOR
-        || minor_version > P64IMAGE_SNAP_MINOR) {
-        log_error(drive_snapshot_log,
-                  "Snapshot module version (%d.%d) newer than %d.%d.",
-                  major_version, minor_version,
-                  P64IMAGE_SNAP_MAJOR, P64IMAGE_SNAP_MINOR);
+    /* reject snapshot modules newer than what we can handle (this VICE is too old) */
+    if (snapshot_version_is_bigger(major_version, minor_version, P64IMAGE_SNAP_MAJOR, P64IMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_HIGHER_VERSION);
+        snapshot_module_close(m);
+        return -1;
+    }
+
+    /* reject snapshot modules older than what we can handle (the snapshot is too old) */
+    if (snapshot_version_is_smaller(major_version, minor_version, P64IMAGE_SNAP_MAJOR, P64IMAGE_SNAP_MINOR)) {
+        snapshot_set_error(SNAPSHOT_MODULE_INCOMPATIBLE);
+        snapshot_module_close(m);
+        return -1;
     }
 
     if (SMR_DW(m, &size) < 0) {

--- a/third_party/vice-3.3/src/drive/drive-snapshot.c
+++ b/third_party/vice-3.3/src/drive/drive-snapshot.c
@@ -239,7 +239,8 @@ int drive_snapshot_write_module(snapshot_t *s, int save_disks, int save_roms)
     for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (drive->enable) {
-            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
+            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000 ||
+                drive->type == DRIVE_TYPE_CMDHD) {
                 if (drivecpu65c02_snapshot_write_module(drive_context[i], s) < 0) {
                     return -1;
                 }
@@ -560,6 +561,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         case DRIVE_TYPE_1581:
         case DRIVE_TYPE_2000:
         case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_CMDHD:
         case DRIVE_TYPE_2031:
         case DRIVE_TYPE_1001:
         case DRIVE_TYPE_2040:
@@ -594,6 +596,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         case DRIVE_TYPE_1581:
         case DRIVE_TYPE_2000:
         case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_CMDHD:
         case DRIVE_TYPE_2031:
         case DRIVE_TYPE_1001:
             /* drive 1 does not allow dual disk drive */
@@ -627,6 +630,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         case DRIVE_TYPE_1581:
         case DRIVE_TYPE_2000:
         case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_CMDHD:
         case DRIVE_TYPE_2031:
         case DRIVE_TYPE_1001:
         case DRIVE_TYPE_2040:
@@ -661,6 +665,7 @@ int drive_snapshot_read_module(snapshot_t *s)
         case DRIVE_TYPE_1581:
         case DRIVE_TYPE_2000:
         case DRIVE_TYPE_4000:
+        case DRIVE_TYPE_CMDHD:
         case DRIVE_TYPE_2031:
         case DRIVE_TYPE_1001:
             /* drive 1 does not allow dual disk drive */
@@ -691,7 +696,8 @@ int drive_snapshot_read_module(snapshot_t *s)
     for (i = 0; i < DRIVE_NUM; i++) {
         drive = drive_context[i]->drive;
         if (drive->enable) {
-            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000) {
+            if (drive->type == DRIVE_TYPE_2000 || drive->type == DRIVE_TYPE_4000 ||
+                drive->type == DRIVE_TYPE_CMDHD) {
                 if (drivecpu65c02_snapshot_read_module(drive_context[i], s) < 0) {
                     return -1;
                 }
@@ -791,7 +797,7 @@ static int drive_snapshot_write_image_module(snapshot_t *s, unsigned int dnr)
 
     drive = drive_context[dnr]->drive;
 
-    if (drive->image == NULL) {
+    if (drive->image == NULL || drive->type == DRIVE_TYPE_CMDHD) {
         sprintf(snap_module_name, "NOIMAGE%u", dnr);
     } else {
         sprintf(snap_module_name, "IMAGE%u", dnr);
@@ -803,7 +809,7 @@ static int drive_snapshot_write_image_module(snapshot_t *s, unsigned int dnr)
         return -1;
     }
 
-    if (drive->image == NULL) {
+    if (drive->image == NULL || drive->type == DRIVE_TYPE_CMDHD) {
         if (snapshot_module_close(m) < 0) {
             return -1;
         }
@@ -859,7 +865,10 @@ static int drive_snapshot_read_image_module(snapshot_t *s, unsigned int dnr)
     m = snapshot_module_open(s, snap_module_name,
                              &major_version, &minor_version);
     if (m != NULL) {
-        file_system_detach_disk(dnr + 8);
+        /* do not detach an existing DHD image as they aren't saved in the snapshot */
+        if (drive->type != DRIVE_TYPE_CMDHD) {
+            file_system_detach_disk(dnr + 8);
+        }
         snapshot_module_close(m);
         return 0;
     }

--- a/third_party/vice-3.3/src/snapshot.c
+++ b/third_party/vice-3.3/src/snapshot.c
@@ -995,3 +995,51 @@ int snapshot_version_at_least(uint8_t major_version, uint8_t minor_version, uint
 
     return 0;
 }
+
+/* check if version == required version */
+int snapshot_version_is_equal(uint8_t major_version, uint8_t minor_version,
+                              uint8_t major_version_required, uint8_t minor_version_required)
+{
+    if ((major_version == major_version_required) && (minor_version == minor_version_required)) {
+        return 1;
+    }
+    return 0;
+}
+
+/* check if version > required version */
+int snapshot_version_is_bigger(uint8_t major_version, uint8_t minor_version,
+                               uint8_t major_version_required, uint8_t minor_version_required)
+{
+    if (major_version > major_version_required) {
+        return 1;
+    }
+
+    if (major_version < major_version_required) {
+        return 0;
+    }
+
+    if (minor_version > minor_version_required) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/* check if version < required version */
+int snapshot_version_is_smaller(uint8_t major_version, uint8_t minor_version,
+                                uint8_t major_version_required, uint8_t minor_version_required)
+{
+    if (major_version < major_version_required) {
+        return 1;
+    }
+
+    if (major_version > major_version_required) {
+        return 0;
+    }
+
+    if (minor_version < minor_version_required) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/third_party/vice-3.3/src/snapshot.h
+++ b/third_party/vice-3.3/src/snapshot.h
@@ -151,6 +151,10 @@ extern void snapshot_set_error(int error);
 
 extern int snapshot_version_at_least(uint8_t major_version, uint8_t minor_version, uint8_t major_version_required, uint8_t minor_version_required);
 
+extern int snapshot_version_is_equal(uint8_t major_version, uint8_t minor_version, uint8_t major_version_required, uint8_t minor_version_required);
+extern int snapshot_version_is_bigger(uint8_t major_version, uint8_t minor_version, uint8_t major_version_required, uint8_t minor_version_required);
+extern int snapshot_version_is_smaller(uint8_t major_version, uint8_t minor_version, uint8_t major_version_required, uint8_t minor_version_required);
+
 #define SNAPVAL snapshot_version_at_least
 
 #endif

--- a/third_party/vice-3.3/src/vdrive/vdrive-snapshot.c
+++ b/third_party/vice-3.3/src/vdrive/vdrive-snapshot.c
@@ -67,7 +67,7 @@ int vdrive_snapshot_module_write(snapshot_t *s)
         resources_get_int_sprintf("Drive%iTrueEmulation", &tde, i);
         if (tde == 0) {
             floppy = file_system_get_vdrive(i);
-            for (j = 0; j <= 3; j++) {
+            for (j = 0; j <= 1; j++) {
                 image = vdrive_get_image(floppy, j);
                 if (image != NULL) {
                     snprintf(snap_module_name, SNAP_MODNAME_SIZE, "VDRIVEIMAGE%i", i);
@@ -94,7 +94,7 @@ int vdrive_snapshot_module_read(snapshot_t *s)
     for (i = 8; i <= 11; i++) {
         resources_get_int_sprintf("Drive%iTrueEmulation", &tde, i);
         if (tde == 0) {
-            for (j = 0; j <= 3; j++) {
+            for (j = 0; j <= 1; j++) {
                 snprintf(snap_module_name, SNAP_MODNAME_SIZE, "VDRIVEIMAGE%i", i);
                 m = snapshot_module_open(s, snap_module_name, &major_version, &minor_version);
                 if (m == NULL) {

--- a/third_party/vice-3.3/src/vdrive/vdrive-snapshot.c
+++ b/third_party/vice-3.3/src/vdrive/vdrive-snapshot.c
@@ -102,8 +102,7 @@ int vdrive_snapshot_module_read(snapshot_t *s)
                 }
 
                 /* FIXME: this gives a linker error? */
-                /* if (snapshot_version_is_bigger(major_version, minor_version, SNAP_MAJOR, SNAP_MINOR)) { */
-                if (major_version > SNAP_MAJOR || minor_version > SNAP_MINOR) {
+                if (snapshot_version_is_bigger(major_version, minor_version, SNAP_MAJOR, SNAP_MINOR)) {
                     log_message(vdrive_snapshot_log,
                                 "Snapshot module version (%d.%d) newer than %d.%d.",
                                 major_version, minor_version, SNAP_MAJOR, SNAP_MINOR);


### PR DESCRIPTION
Support drive-snapshot for 4 drives, tde per drive and backwards compatibility

Backport support for 4 drives
Backport basic CDMHD idenification
Backport checking functions
Fix references to disk images that do not exist in vdrive
Fix p64image to reference correct version information

Rewrite parts of drive snapshot to support backwards compatability and not cause the reseting of TDE to 0 which could happen if settings were saved after loading a problem snapshot or a failed load.

### Details

Extend DRIVE snapshots to cover all four drive contexts and persist each drive's TrueEmulation setting. Version 1.6 adds four TDE bytes while retaining support for older snapshots: versions 1.0-1.4 restore their original two-drive layout, and 1.5 snapshots derive TDE from the restored drive types.

Do not disable TDE when a snapshot has no DRIVE module. Snapshot loading can fail after this path, and resetting the resource would persist an unintended disabled-drive configuration after the failed load.

CMDHD state remains unsupported: its 65C02 snapshot writer includes 64 KiB of RAM that its reader does not consume, causing snapshot loads to fail. CMDHD CPU/device modules are therefore omitted for new snapshots and ignored for existing ones, allowing the rest of the machine snapshot to restore.