### PR TITLE
Pet crash fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.9 pre-release
+  * Fix PET 1080p HDMI modes crashing on boot with the CRT shader enabled
+    * Add gpu_mem=128 to machines.txt and enable for PET machine
+    * Add graceful fallback if gpu_mem=64 is exceeded (disable shader)
+
 ## 5.0.8 pre-release
   * Faster storage access
     * Attaching large files is much faster (a 16 MB REU image went from ~12.5 seconds to ~1.1 seconds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
   * Fix PET 1080p HDMI modes crashing on boot with the CRT shader enabled
     * Add gpu_mem=128 to machines.txt and enable for PET machine
     * Add graceful fallback if gpu_mem=64 is exceeded (disable shader)
+  * Fix PET boot crash where VICE's video callbacks run before the menu is built (NULL menu items -> bad stretch -> assert/data abort on Circle 51)
+  * Tolerate stale (PET) settings file entries
 
 ## 5.0.8 pre-release
   * Faster storage access

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -133,6 +133,15 @@ Valid video output types are HDMI, Composite, DPI
 For HDMI, you should choose either a 50hz or 60hz mode.
 See below for notes on using DPI.
 
+A `gpu_mem` parameter may be added to a config to raise the GPU memory
+split floor for that mode. This is needed for 1080p HDMI modes with the
+CRT shader enabled, where the default 64MB split is not enough to
+allocate the full screen render surface (the PET 1080p configs set
+`gpu_mem=128` for this reason). Switching to any config that does not
+specify `gpu_mem` resets the split back to the 64MB default, so a value
+you set by hand in `config.txt` will not survive a machine switch unless
+you also add it to the `machines.txt` entry.
+
 If you want to use composite out, you MUST set machine_timing parameter to ntsc-composite or pal-composite and set the corresponding sdtv_mode. Otherwise, you will have audio synchronization issues.
 
 Raspberry Pi Video Mode     | machine_timing | cycles_per_second

--- a/sdcard/machines.txt
+++ b/sdcard/machines.txt
@@ -30,6 +30,8 @@
 # hdmi_mode
 # hdmi_timing
 # hdmi_cvt
+# gpu_mem (raises the GPU split floor for this profile; other
+#          profiles reset it to the 64MB default)
 #
 # cmdline.txt options available (See README.md)
 # ----------------------------------------------------
@@ -344,6 +346,8 @@ hdmi_mode=16
 machine_timing=ntsc-hdmi
 scaling_params=376,270,1504,1080
 scaling_params2=696,270,1392,1080
+# 1080p + CRT shader needs a bigger GPU split than the 64MB default.
+gpu_mem=128
 
 [PET/NTSC/Composite/VICE 480p@60Hz]
 disable_overscan=1
@@ -360,6 +364,8 @@ hdmi_mode=31
 machine_timing=pal-hdmi
 scaling_params=376,270,1504,1080
 scaling_params2=696,270,1392,1080
+# 1080p + CRT shader needs a bigger GPU split than the 64MB default.
+gpu_mem=128
 
 [PET/PAL/Composite/VICE 576p@50Hz]
 disable_overscan=1

--- a/src/fbl.cpp
+++ b/src/fbl.cpp
@@ -781,6 +781,8 @@ void FrameBufferLayer::Show() {
 
   int dst_w;
   int dst_h;
+
+  // SetStretch() refuses a zero component, so these should always hold.
   assert (hstretch_ != 0);
   assert (vstretch_ != 0);
 
@@ -1213,6 +1215,16 @@ void FrameBufferLayer::SetSrcRect(int x, int y, int w, int h) {
 
 // Set horizontal/vertical multipliers
 void FrameBufferLayer::SetStretch(double hstretch, double vstretch, int hintstr, int vintstr, int use_hintstr, int use_vintstr) {
+  if (hstretch == 0 || vstretch == 0) {
+    // A zero component would collapse the destination rect and trips an
+    // assert in Show(). Should not happen now that the menu code passes
+    // defaults before it is built, but keep this as a last resort so a
+    // bad value degrades instead of halting the machine.
+    printf("fbl: SetStretch layer=%d given a zero component; keeping usable value\n",
+           layer_);
+    if (hstretch == 0) hstretch = hstretch_ != 0 ? hstretch_ : 1.0;
+    if (vstretch == 0) vstretch = vstretch_ != 0 ? vstretch_ : 1.0;
+  }
   hstretch_ = hstretch;
   vstretch_ = vstretch;
   hintstr_ = hintstr;

--- a/src/fbl.cpp
+++ b/src/fbl.cpp
@@ -918,21 +918,68 @@ void FrameBufferLayer::Show() {
     egl_native_window_.width = display_width_;
     egl_native_window_.height = display_height_;
     egl_surface_ = eglCreateWindowSurface(egl_display_, egl_config_, &egl_native_window_, NULL );
-    assert(egl_surface_ != EGL_NO_SURFACE);
 
-    EGLBoolean result;
-    result = eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_);
-    assert(EGL_FALSE != result);
-    //check("eglMakeCurrent");
+    if (egl_surface_ == EGL_NO_SURFACE) {
+      // The VideoCore could not allocate the window surface. This is
+      // typically GPU memory exhaustion: a triple buffered full screen
+      // surface at 1080p needs ~25MB and does not fit the default
+      // gpu_mem=64 split. Rather than halt the machine, fall back to the
+      // plain dispmanx scaling path so the emulator still runs, just
+      // without the CRT shader for this layer.
+      printf("fbl: eglCreateWindowSurface failed (%dx%d); "
+             "disabling CRT shader for this layer\n",
+             display_width_, display_height_);
 
-    ShaderInit();
-    ShaderUpdate();
+      // Remove the element we just added. It was set up for the shader
+      // (1:1 src rect, no dispmanx scaling); we re-add it below with a
+      // cropping src rect so dispmanx does the scaling instead.
+      dispman_update = vc_dispmanx_update_start(0);
+      vc_dispmanx_element_remove(dispman_update, dispman_element_);
+      vc_dispmanx_update_submit(dispman_update, NULL, NULL);
 
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
+      // Drop the GL context created in Allocate(). The dispmanx-only
+      // path does not use it and FreeInternal() keys its cleanup off
+      // uses_shader_, so it would otherwise leak.
+      eglDestroyContext(egl_display_, egl_context_);
+      egl_context_ = EGL_NO_CONTEXT;
+      uses_shader_ = false;
 
-    eglSwapInterval(egl_display_, 0);
-    eglSwapBuffers(egl_display_, egl_surface_);
+      vc_dispmanx_rect_set(&src_rect_,
+                           src_x_ << 16,
+                           src_y_ << 16,
+                           src_w_ << 16,
+                           src_h_ << 16);
+
+      dispman_update = vc_dispmanx_update_start(0);
+      assert( dispman_update );
+      rnum_ = 0;
+      dispman_element_ = vc_dispmanx_element_add(dispman_update,
+                                                dispman_display_,
+                                                layer_,
+                                                &scale_dst_rect_,
+                                                dispman_resource_[rnum_],
+                                                &src_rect_,
+                                                DISPMANX_PROTECTION_NONE,
+                                                &alpha_,
+                                                NULL,             // clamp
+                                                DISPMANX_NO_ROTATE);
+      ret = vc_dispmanx_update_submit(dispman_update, NULL, NULL);
+      assert( ret == 0 );
+    } else {
+      EGLBoolean result;
+      result = eglMakeCurrent(egl_display_, egl_surface_, egl_surface_, egl_context_);
+      assert(EGL_FALSE != result);
+      //check("eglMakeCurrent");
+
+      ShaderInit();
+      ShaderUpdate();
+
+      glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+      glClear(GL_COLOR_BUFFER_BIT);
+
+      eglSwapInterval(egl_display_, 0);
+      eglSwapBuffers(egl_display_, egl_surface_);
+    }
   }
 
   if (mode_ == VC_IMAGE_8BPP) {

--- a/third_party/common/menu.c
+++ b/third_party/common/menu.c
@@ -61,7 +61,7 @@
 
 extern void reboot(void);
 
-#define VERSION_STRING "5.0.8"
+#define VERSION_STRING "5.0.9"
 
 #ifdef RASPI_LITE
 #define VARIANT_STRING "-Lite"

--- a/third_party/common/menu.c
+++ b/third_party/common/menu.c
@@ -944,6 +944,24 @@ static int is_mouse_device(int device) {
   return device == JOYDEV_MOUSE || device == JOYDEV_MOUSE_MICROMYS;
 }
 
+// Returns the JOYDEV_* value a joyport menu item currently selects, but
+// only if that choice is valid for this machine. A settings file carried
+// over from another machine/version can select a choice that is out of
+// range or disabled here (e.g. a mouse on a PET userport); pushing that
+// to VICE pops up a "device N is not registered" error. In that case
+// reset the item to "None" (index 0) so the menu stays consistent and a
+// later Save cleans up the file.
+static int validated_port_choice(struct menu_item* it) {
+  if (it == NULL) {
+    return JOYDEV_NONE;
+  }
+  if (it->value < 0 || it->value >= it->num_choices ||
+      it->choice_disabled[it->value]) {
+    it->value = 0;
+  }
+  return it->choice_ints[it->value];
+}
+
 static void set_need_mouse() {
    int need_mouse = 0;
    int index;
@@ -1026,20 +1044,16 @@ void ui_set_joy_items() {
   }
 
   if (port_1_menu_item) {
-     set_joy_item_to_value(1,
-         port_1_menu_item->choice_ints[port_1_menu_item->value]);
+     set_joy_item_to_value(1, validated_port_choice(port_1_menu_item));
   }
   if (port_2_menu_item) {
-     set_joy_item_to_value(2,
-         port_2_menu_item->choice_ints[port_2_menu_item->value]);
+     set_joy_item_to_value(2, validated_port_choice(port_2_menu_item));
   }
   if (port_3_menu_item) {
-     set_joy_item_to_value(3,
-         port_3_menu_item->choice_ints[port_3_menu_item->value]);
+     set_joy_item_to_value(3, validated_port_choice(port_3_menu_item));
   }
   if (port_4_menu_item) {
-     set_joy_item_to_value(4,
-         port_4_menu_item->choice_ints[port_4_menu_item->value]);
+     set_joy_item_to_value(4, validated_port_choice(port_4_menu_item));
   }
   set_need_mouse();
 }
@@ -1053,6 +1067,15 @@ static int do_use_int_scaling(int layer, int silent) {
   } else {
     if (!silent)
        ui_error("Bad display num");
+    return 0;
+  }
+
+  // Needs the border/stretch menu items; nothing to do if the menu is not
+  // built yet (can happen if a video callback fires before build_menu()).
+  if (h_border_item[canvas_index] == NULL ||
+      v_border_item[canvas_index] == NULL ||
+      h_stretch_item[canvas_index] == NULL ||
+      v_stretch_item[canvas_index] == NULL) {
     return 0;
   }
 
@@ -1389,19 +1412,19 @@ static int save_settings() {
 // Make joydev reflect menu choice
 static void ui_set_joy_devs() {
   if (port_1_menu_item) {
-    joydevs[0].device = port_1_menu_item->choice_ints[port_1_menu_item->value];
+    joydevs[0].device = validated_port_choice(port_1_menu_item);
   }
 
   if (port_2_menu_item) {
-    joydevs[1].device = port_2_menu_item->choice_ints[port_2_menu_item->value];
+    joydevs[1].device = validated_port_choice(port_2_menu_item);
   }
 
   if (port_3_menu_item) {
-    joydevs[2].device = port_3_menu_item->choice_ints[port_3_menu_item->value];
+    joydevs[2].device = validated_port_choice(port_3_menu_item);
   }
 
   if (port_4_menu_item) {
-    joydevs[3].device = port_4_menu_item->choice_ints[port_4_menu_item->value];
+    joydevs[3].device = validated_port_choice(port_4_menu_item);
   }
 }
 
@@ -1769,6 +1792,25 @@ static void load_settings() {
     }
   }
   fclose(fp);
+
+  // Pin stretch factors read from the file to a sane value. An
+  // out-of-range value (in particular 0, from a corrupt or very old
+  // hand-edited settings file) would otherwise be sent to the frame
+  // buffer layer as-is and collapse the display. Guard the upper bound
+  // too: the item's max can itself be left bogus if geometry was not
+  // known when the menu was built.
+  struct menu_item* stretch_items[] = {
+    h_stretch_item[0], v_stretch_item[0],
+    emux_machine_class == BMC64_MACHINE_CLASS_C128 ? h_stretch_item[1] : NULL,
+    emux_machine_class == BMC64_MACHINE_CLASS_C128 ? v_stretch_item[1] : NULL,
+  };
+  for (int si = 0; si < 4; si++) {
+    struct menu_item* it = stretch_items[si];
+    if (it == NULL) continue;
+    int lo = it->min > 0 ? it->min : 1;
+    if (it->value < lo) it->value = lo;
+    if (it->max > lo && it->value > it->max) it->value = it->max;
+  }
 
   update_wifi_menu_enabled();
   emux_load_settings_done();
@@ -2298,6 +2340,19 @@ static void do_video_settings(int layer) {
      return;
   }
 
+  // VICE's video callbacks (emux_frame_buffer_changed / emux_geometry_changed)
+  // can fire from crtc_init()/vicii_init(), which run before build_menu()
+  // has created these menu items. We must not dereference them when NULL,
+  // but we must still run to the end of this function: the call it makes
+  // to emux_apply_video_adjustments() is what allocates the UI frame
+  // buffer (via emux_geometry_changed -> ui_geometry_changed). So fall
+  // back to sane defaults for the not-yet-existing items; build_menu()
+  // calls do_video_settings() again with the real values.
+  int menu_ready = h_stretch_item[canvas_index] != NULL;
+  int default_h_stretch =
+      emux_machine_class == BMC64_MACHINE_CLASS_VIC20 ? DEFAULT_VIC_H_STRETCH
+                                                     : DEFAULT_VICII_H_STRETCH;
+
   hcenter_item = h_center_item[canvas_index];
   vcenter_item = v_center_item[canvas_index];
   hborder_item = h_border_item[canvas_index];
@@ -2309,12 +2364,12 @@ static void do_video_settings(int layer) {
   use_h_int_stretch = use_h_integer_stretch[canvas_index];
   use_v_int_stretch = use_v_integer_stretch[canvas_index];
 
-  int hc = hcenter_item->value;
-  int vc = vcenter_item->value;
+  int hc = menu_ready ? hcenter_item->value : 0;
+  int vc = menu_ready ? vcenter_item->value : 0;
   int vid_hc = hc;
   int vid_vc = vc;
 
-  if (emux_machine_class == BMC64_MACHINE_CLASS_C128) {
+  if (menu_ready && emux_machine_class == BMC64_MACHINE_CLASS_C128) {
      if ((active_display_item->value == MENU_ACTIVE_DISPLAY_VICII && layer == FB_LAYER_VIC) ||
          (active_display_item->value == MENU_ACTIVE_DISPLAY_VDC && layer == FB_LAYER_VDC)) {
         lpad = 0; rpad = 0; tpad = 0; bpad = 0; zlayer = layer == FB_LAYER_VIC ? 0 : 1;
@@ -2364,13 +2419,13 @@ static void do_video_settings(int layer) {
      lpad = 0; rpad = 0; tpad = 0; bpad = 0; zlayer = 0;
   }
 
-  int h = hborder_item->value;
-  int v = vborder_item->value;
-  double hs = (double)(h_str_item->value) / 1000.0d;
-  double vs = (double)(v_str_item->value) / 1000.0d;
+  int h = menu_ready ? hborder_item->value : 0;
+  int v = menu_ready ? vborder_item->value : 0;
+  double hs = (double)(menu_ready ? h_str_item->value : default_h_stretch) / 1000.0d;
+  double vs = (double)(menu_ready ? v_str_item->value : DEFAULT_VICII_V_STRETCH) / 1000.0d;
 
   double vid_hstretch = hs;
-  if (emux_machine_class == BMC64_MACHINE_CLASS_C128 &&
+  if (menu_ready && emux_machine_class == BMC64_MACHINE_CLASS_C128 &&
           active_display_item->value == MENU_ACTIVE_DISPLAY_SIDE_BY_SIDE) {
      // For side-by-side, it makes more sense to fill horizontal then scale
      // vertical since we just cut horizontal in half. So pass in negative
@@ -4767,7 +4822,12 @@ void emux_geometry_changed(int layer) {
 
 void emux_frame_buffer_changed(int layer) {
   int canvas_index = layer == FB_LAYER_VIC ? VIC_INDEX : VDC_INDEX;
-  if (use_scaling_params_item[canvas_index]->value) {
+  // This can be called from crtc_init()/vicii_init(), before build_menu()
+  // has created the menu items. The integer-scaling check needs them, but
+  // do_video_settings() must always run (it allocates the UI frame buffer),
+  // and it tolerates the items being NULL.
+  if (use_scaling_params_item[canvas_index] != NULL &&
+      use_scaling_params_item[canvas_index]->value) {
      if (!do_use_int_scaling(layer, 1 /* silent */)) {
         use_scaling_params_item[canvas_index]->value = 0;
      }

--- a/third_party/common/menu_switch.c
+++ b/third_party/common/menu_switch.c
@@ -47,6 +47,14 @@
 #define ERROR_9 256
 #define ERROR_10 512
 
+// BMC64's default GPU memory split (MB). Most machine profiles are happy
+// with this. A profile that needs more (currently only the PET 1080p HDMI
+// modes, where the CRT shader's triple-buffered full screen EGL surface
+// does not fit a 64MB split) asks for a higher floor with a gpu_mem= line
+// in machines.txt; switching to any profile that doesn't ask resets the
+// split back to this default.
+#define DEFAULT_GPU_MEM 64
+
 struct s_cfg_flags {
   // Have flags for cmdline.txt
   int have_cycles_per_second;
@@ -63,6 +71,7 @@ struct s_cfg_flags {
 
   // Have flags for config.txt
   int have_kernel;
+  int have_gpu_mem;
   int have_hdmi_timings;
   int have_cvt;
   int have_dpi_timings;
@@ -317,6 +326,22 @@ static void apply_override_s(char *line,
        } else {
           line[0] = '\0';
        }
+       return;
+    }
+
+    // gpu_mem: a profile can raise the floor (machines.txt gpu_mem=N) but
+    // never lowers a bigger value the user chose themselves. Any profile
+    // that doesn't ask resets the split back to the BMC64 default.
+    if(strcmp(key, "gpu_mem") == 0) {
+       cfg_flags->have_gpu_mem = 1;
+       struct machine_option* gm = find_option("gpu_mem", head->options);
+       int want = DEFAULT_GPU_MEM;
+       if (gm) {
+          int floor = atoi(gm->value);
+          int current = atoi(value);
+          want = current > floor ? current : floor;
+       }
+       snprintf(line, CONFIG_TXT_LINE_LEN, "gpu_mem=%d\n", want);
        return;
     }
 
@@ -694,6 +719,17 @@ static int apply_config(struct machine_entry* head, int pi_model, struct s_cfg_f
   // now.
   if (!cfg_flags->have_kernel && cfg_flags->need_kernel) {
     fprintf(fp2,"kernel=%s\n", kernel_name);
+  }
+
+  // If config.txt had no gpu_mem line at all, add the floor this profile
+  // asks for (e.g. PET 1080p). Profiles that don't ask inherit the
+  // firmware default and need no line.
+  if (!cfg_flags->have_gpu_mem) {
+    found = find_option("gpu_mem", head->options);
+    if (found) {
+       int floor = atoi(found->value);
+       fprintf(fp2,"gpu_mem=%d\n", floor > DEFAULT_GPU_MEM ? floor : DEFAULT_GPU_MEM);
+    }
   }
 
   // Ensure we add custom timings if present.

--- a/third_party/common/ui.c
+++ b/third_party/common/ui.c
@@ -263,6 +263,10 @@ void ui_draw_rect_buf(int x, int y, int w, int h, int color, int fill,
     dst_pitch = ui_fb_pitch;
     dst = ui_fb;
   }
+  // Still nothing to draw into (ui frame buffer not allocated yet).
+  if (dst == NULL) {
+    return;
+  }
   x2 = x + w;
   y2 = y + h;
   for (xx = x, yy = y; yy < y2; xx++) {
@@ -488,6 +492,11 @@ static void ui_action_frame() {
 
 void ui_render_single_frame() {
   menu_update_network_status();
+
+  // Nothing to render into until ui_geometry_changed() has allocated it.
+  if (ui_fb == NULL) {
+    return;
+  }
 
   // Start with transparent
   memset(ui_fb, TRANSPARENT_COLOR, ui_fb_h * ui_fb_pitch);
@@ -1140,6 +1149,13 @@ static void ui_draw_shadow_text(const char* txt, int *x, int *y, int col) {
 void ui_render_now(int menu_stack_index) {
   int index = 0;
   int indent = 0;
+
+  // The UI frame buffer is allocated lazily by ui_geometry_changed(). If
+  // something tries to render before that has happened (e.g. an early
+  // ui_error()), there is nothing to draw into.
+  if (ui_fb == NULL) {
+    return;
+  }
 
   if (menu_stack_index == -1) {
     menu_stack_index = current_menu;


### PR DESCRIPTION
Multiple PET fixes #341 

  * Fix PET 1080p HDMI modes crashing on boot with the CRT shader enabled
    * Add gpu_mem=128 to machines.txt and enable for PET machine
    * Add graceful fallback if gpu_mem=64 is exceeded (disable shader)
  * Fix PET boot crash where VICE's video callbacks run before the menu is built (NULL menu items -> bad stretch -> assert/data abort on Circle 51)
  * Tolerate stale (PET) settings file entries