### PR TITLE
Add ROMs sub-menu to the Machine menu for Plus/4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.10 pre-release
+  * Add a `ROMs` sub-menu to the `Machine` menu in Plus/4 mode
+
 ## 5.0.9 pre-release
   * Fix PET 1080p HDMI modes crashing on boot with the CRT shader enabled
     * Add gpu_mem=128 to machines.txt and enable for PET machine

--- a/third_party/common/menu.c
+++ b/third_party/common/menu.c
@@ -61,7 +61,7 @@
 
 extern void reboot(void);
 
-#define VERSION_STRING "5.0.9"
+#define VERSION_STRING "5.0.10"
 
 #ifdef RASPI_LITE
 #define VARIANT_STRING "-Lite"

--- a/third_party/common/menu.h
+++ b/third_party/common/menu.h
@@ -298,7 +298,7 @@ typedef enum {
 
    MENU_MAKE_CART_DEFAULT,
 
-   // C64/Vic20
+   // C64/Vic20/Plus4
    MENU_LOAD_KERNAL,
    MENU_KERNAL_FILE,
    MENU_LOAD_BASIC,

--- a/third_party/vice-3.3/src/arch/raspi/plus4/menu_plus4.c
+++ b/third_party/vice-3.3/src/arch/raspi/plus4/menu_plus4.c
@@ -172,6 +172,11 @@ void cartridge_set_default(void) { }
 void cartridge_freeze(void) { }
 
 void emux_add_machine_options(struct menu_item* parent) {
+  struct menu_item* roms_parent = ui_menu_add_folder(parent, "ROMs...");
+  ui_menu_add_button(MENU_LOAD_KERNAL, roms_parent, "Load Kernal ROM...");
+  ui_menu_add_button(MENU_LOAD_BASIC, roms_parent, "Load Basic ROM...");
+  ui_menu_add_button(MENU_LOAD_CHARGEN, roms_parent, "Load Chargen ROM...");
+
   struct menu_item* model_parent = ui_menu_add_folder(parent, "Model...");
   int timing = circle_get_machine_timing();
 


### PR DESCRIPTION
The Plus/4 does not currently have the ability to changes ROMs for things like JiffyDOS. This change adds the ROMs sub-menu to the Machine menu on CBM-264 class machines.